### PR TITLE
Downgrade xlrd dependency to 1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
         'click',
         'click_log==0.1.8',
         'colorama',
-        'xlrd',
+        'xlrd==1.2.0',
         'networkx',
     ]
 )


### PR DESCRIPTION
`xlrd>=2.0.0` no longer supports reading in `xlsx` files. This PR pins the `xlrd` dependency to `1.2.0` to re-enable `xlsx` file support for rxncon.